### PR TITLE
Update GATracker.swift

### DIFF
--- a/GATracker.swift
+++ b/GATracker.swift
@@ -133,16 +133,16 @@ class GATracker {
         self.send("screenview", params: params)
     }
     
-    func event(category: String, action: String, var label: String?, customParameters: Dictionary<String, String>?) {
+    func event(category: String, action: String, label: String?, customParameters: Dictionary<String, String>?) {
         /*
             An event hit with category, action, label
         */
-        if label == nil {
-            label = ""
-        }
+        
+        //set the local variable _label to label or "" if that is nil
+        let _label = label == nil ? "" : label!
        
         //event parameters category, action and label
-        var params = ["ec" : category, "ea" : action, "el" : label!]
+        var params = ["ec" : category, "ea" : action, "el" : _label]
         if (customParameters != nil) {
             for (key, value) in customParameters! {
                 params.updateValue(value, forKey: key)


### PR DESCRIPTION
var parameters deprecated and will soon be error; copies label parameter to separate local variable
